### PR TITLE
Hotfix/#36 #58 #70 - Ingestion restarting over and over

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,6 @@ services:
       - ./storage/extracted:/app/storage/extracted  # Shared storage for metadata
     networks:
       - marp-network
-    restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
       interval: 30s


### PR DESCRIPTION
Fixed docker compose was restarting the ingestion service, now it runs once and then exits, like all the services.
Maintained code functionality 